### PR TITLE
integrate with travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "3.3"
   - "pypy"
 install:
-  - sudo pip install docutils
+  - pip install docutils
 script:
   - make
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - "2.7"
   - "3.2"
   - "3.3"
-  - "pypy"
 install:
   - pip install docutils
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+---
+
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "pypy"
+install:
+  - sudo pip install docutils
+script:
+  - make
+  - python setup.py install

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ euclid.tex: euclid.txt
 	$(REST_LATEX) $< > $@
 
 doctest: euclid.txt
-	python -c 'import doctest; doctest.testfile("$<")'
+	./runtests.py $<
 
 clean:
 	rm -f *.pyc *.pyo euclid.tex 

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+import doctest
+import sys
+
+
+if __name__ == '__main__':
+    results = doctest.testfile(sys.argv[1])
+    sys.exit(int(results.failed != 0))


### PR DESCRIPTION
Along with my previous pull request to update the docs and Makefile (#6), this request integrates with travis-ci.org to provide continuous integration. It verifies that the pyeuclid docs and tests successfully build and that pyeuclid installs properly an pythons 2.6, .27, 3.2, 3.3 and pypy.