### PR TITLE
A fix for Matrix4.new_look_at which returns incorrect results.

### DIFF
--- a/euclid.py
+++ b/euclid.py
@@ -1167,7 +1167,8 @@ class Matrix4:
       y = z.cross(x)
       
       m = cls.new_rotate_triple_axis(x, y, z)
-      m.d, m.h, m.l = eye.x, eye.y, eye.z
+      m.transpose()
+      m.d, m.h, m.l = -x.dot(eye), -y.dot(eye), -z.dot(eye)
       return m
     new_look_at = classmethod(new_look_at)
     


### PR DESCRIPTION
A bug in pyeuclid was discussed in Answear 1 at http://stackoverflow.com/questions/25027045/applying-glm-like-perspective-and-lookat-calculations-results-in-my-shape-di , this is a fix for that bug.

Working code making use of this patch can be found at https://github.com/01AutoMonkey/open.gl-tutorials-to-pyglet/search?utf8=%E2%9C%93&q=new_look_at or simply by running file 4-2, 5-1 or 5-2 found in https://github.com/01AutoMonkey/open.gl-tutorials-to-pyglet