### PR TITLE
Fix setup.py to install euclid.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@ from setuptools import find_packages, setup
 setup(
     name='euclid',
     version='1.0.dev0',
-    packages=find_packages(),
+    
+    py_modules=['euclid'],
 
     setup_requires=[
         'pytest-runner',


### PR DESCRIPTION
Installing this package with setuptools leaves out `euclid.py`. Thus after the installation, you cannot do `import euclid`. This is due to an erroneous `setup.py` which is fixed in this PR. The solution came from: http://www.agapow.net/programming/python/setuptools-and-the-single-file/
